### PR TITLE
closes #38

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -139,7 +139,7 @@ shinyAppServer = function(input, output, session) {
     )
 
   x = reactive({
-    g = plot_chart(city = input$city_sc)
+    g = plot_chart(city = input$city)
     return(g)
   })
   output$plot = renderPlot({


### PR DESCRIPTION
@Robinlovelace Kinda my fault, kinda your fault, but not so grave given our cracking race to the finish here. I set up that problem with my [initial commit of the health tab](https://github.com/ATFutures/upthat/commit/1722a44761c7bf3acd3fbff233515ea717f950e6#diff-4f632064d1ef846baad1bfd3b7fc8dffR25) when i linked the scenario city to the Scenario City button, and gave it the unambiguous name of `city_sc` rather than `city`. You then switched that tab off in [this commit](https://github.com/ATFutures/upthat/commit/98242a2f32977f2436defaa9a85153026bec4395#diff-4f632064d1ef846baad1bfd3b7fc8dffR26), and so removed the `city_sc` variable from the workspace. And so it started crashing. But really i shoulda thought a bit more at the outset there too, so no blame at all your way on that one.

But ... I now hope that you'll merge this PR, then I intend to immediately re-open #38, because it still needs 1-2 more lines ot ensure that it doesn't crash for cities which don't have scenario data (Bristol)... and yep, that means we also need some Bristol scenario data, but i won't leave that up to you whether you want to open an issue on that or not.

---

Edit: Actually, I'd suggest reinstating the "City" button in the health tab, because it's really good to enable instant visual comparison, rather than having to switch back to maps in order to change city before going to back to scenario tab.