### PR TITLE
filter df before plotting

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -149,6 +149,8 @@ shinyAppServer = function(input, output, session) {
 }
 
 plot_map = function(net, leg_title, update_view = FALSE) {
+  threshold <- 0.01 # constant relative threshold - maybe expose later?
+  net = net [net$flow > (threshold * max (net$flow, na.rm = TRUE)), ]
   net$width = 100 * net$layer / max(net$layer, na.rm = TRUE)
   cols = grDevices::rgb(colourvalues::get_palette("inferno"), maxColorValue = 255)
   variables = seq(min(net$layer), max(net$layer), length.out = 5)


### PR DESCRIPTION
@Robinlovelace should be an easy approve - simply reduces sizes of objects in memory prior to plotting. I still have to re-do all city files in line with [this `who-data` commit and comment](https://github.com/ATFutures/who-data/commit/df54d480301be20b4dd4d50d04594a6f64435a8f), but this PR will help regardless.